### PR TITLE
Prevent panics when data is flat

### DIFF
--- a/asciigraph.go
+++ b/asciigraph.go
@@ -32,7 +32,12 @@ func Plot(series []float64, options ...Option) string {
 		config.Offset = 3
 	}
 
-	ratio := float64(config.Height) / interval
+	var ratio float64
+	if interval != 0 {
+		ratio = float64(config.Height) / interval
+	} else {
+		ratio = 1
+	}
 	min2 := round(minimum * ratio)
 	max2 := round(maximum * ratio)
 
@@ -74,7 +79,14 @@ func Plot(series []float64, options ...Option) string {
 
 	// axis and labels
 	for y := intmin2; y < intmax2+1; y++ {
-		label := fmt.Sprintf("%*.*f", maxWidth+1, precision, maximum-(float64(y-intmin2)*interval/float64(rows)))
+		var magnitude float64
+		if rows > 0 {
+			magnitude = maximum-(float64(y-intmin2)*interval/float64(rows))
+		} else {
+			magnitude = float64(y)
+		}
+
+		label := fmt.Sprintf("%*.*f", maxWidth+1, precision, magnitude)
 		w := y - intmin2
 		h := int(math.Max(float64(config.Offset)-float64(len(label)), 0))
 

--- a/asciigraph_test.go
+++ b/asciigraph_test.go
@@ -12,6 +12,10 @@ func TestPlot(t *testing.T) {
 		expected string
 	}{
 		{
+			[]float64{1, 1, 1, 1, 1},
+			nil,
+			` 1.00 ┼──── `},
+		{
 			[]float64{2, 1, 1, 2, -2, 5, 7, 11, 3, 7, 1},
 			nil,
 			` 11.00 ┤      ╭╮   


### PR DESCRIPTION
This avoids division by 0 that occurs when the incoming data is all one value. Instead of `panic`ing, `Plot` should now plot flat data as expected, in a flat line.