### PR TITLE
Handle NaN first value

### DIFF
--- a/asciigraph.go
+++ b/asciigraph.go
@@ -103,10 +103,12 @@ func Plot(series []float64, options ...Option) string {
 		}
 	}
 
-	y0 := int(round(series[0]*ratio) - min2)
-	var y1 int
+	var y0, y1 int
 
-	plot[rows-y0][config.Offset-1] = "┼" // first value
+	if !math.IsNaN(series[0]) {
+		y0 = int(round(series[0]*ratio) - min2)
+		plot[rows-y0][config.Offset-1] = "┼" // first value
+	}
 
 	for x := 0; x < len(series)-1; x++ { // plot the line
 

--- a/asciigraph_test.go
+++ b/asciigraph_test.go
@@ -193,6 +193,10 @@ func TestPlot(t *testing.T) {
 			nil,
 			` 1.00 ┼─╴╶─`},
 		{
+			[]float64{math.NaN(), 1},
+			nil,
+			` 1.00 ┤╶`},
+		{
 			[]float64{0, 0, 1, 1, math.NaN(), math.NaN(), 3, 3, 4},
 			nil,
 			` 4.00 ┼       ╭


### PR DESCRIPTION
Fixes an overflow error if the first value in the series is NaN.