### PR TITLE
Issue #40 : Changes call `.Plot` on main.go to `.PlotMany`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Options:
     	caption for the graph
   -cc caption color
     	caption color of the plot
+  -d delimiter
+    	data delimiter for splitting data points in the input stream (default ",")
   -f fps
     	set fps to control how frequently graph to be rendered when realtime graph enabled (default 24)
   -h height
@@ -142,6 +144,8 @@ Options:
     	enables realtime graph for data stream
   -sc series color
     	series color of the plot
+  -sn number of series
+    	number of series (columns) in the input data (default 1)
   -ub upper bound
     	upper bound set the maximum value for the vertical axis (ignored if series contains larger values) (default -Inf)
   -w width

--- a/cmd/asciigraph/main.go
+++ b/cmd/asciigraph/main.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/guptarohit/asciigraph"
@@ -87,7 +88,7 @@ func main() {
 
 	flag.Parse()
 
-	data := make([]float64, 0, 64)
+	data := make([][]float64, 0, 64)
 
 	if realTimeDataBuffer == 0 {
 		realTimeDataBuffer = int(width)
@@ -102,19 +103,29 @@ func main() {
 
 	for s.Scan() {
 		word := s.Text()
-		p, err := strconv.ParseFloat(word, 64)
-		if err != nil {
-			log.Printf("ignore %q: cannot parse value", word)
-			continue
+
+		words := strings.Split(word, ",")
+
+		for i, s := range words {
+			p, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				log.Printf("ignore %q: cannot parse value", s)
+			}
+			if i >= len(data) {
+				data = append(data, []float64{p})
+			} else {
+				data[i] = append(data[i], p)
+			}
+
 		}
-		data = append(data, p)
+
 		if enableRealTime {
 			if realTimeDataBuffer > 0 && len(data) > realTimeDataBuffer {
 				data = data[len(data)-realTimeDataBuffer:]
 			}
 
 			if currentTime := time.Now(); currentTime.After(nextFlushTime) || currentTime.Equal(nextFlushTime) {
-				plot := asciigraph.Plot(data,
+				plot := asciigraph.PlotMany(data,
 					asciigraph.Height(int(height)),
 					asciigraph.Width(int(width)),
 					asciigraph.Offset(int(offset)),
@@ -142,7 +153,7 @@ func main() {
 			log.Fatal("no data")
 		}
 
-		plot := asciigraph.Plot(data,
+		plot := asciigraph.PlotMany(data,
 			asciigraph.Height(int(height)),
 			asciigraph.Width(int(width)),
 			asciigraph.Offset(int(offset)),


### PR DESCRIPTION
This solves Issue #40 , `cmd/asciigraph/main.go` was modified to call _always_ PlotMany.

The previous behavior is preserved. In order to add more plots to the graph, separate the values using comma: `,`

I tested this with two files:

```
# data
1
2
3
4
5
```


```
# data_2
1,3
2,3
3,2
4,2
5,2
```

![image](https://github.com/guptarohit/asciigraph/assets/3003032/7bfe9e52-233e-49c8-8a60-ddc3792ff8cf)

If a string don't contain a comma, and the `strings.Split` function is applied to it, you will have an array with one element. This edge case input is a valid argument to `.PlotMany`, so it will draw a single plot on the graph.

A follow up PR to this one could be modify the `-sc` flag so you can put a comma separated list of values (eg: `-sc yellow,red`), and the program the appropriate color for each plot (eg: yellow for the first plot, and red for the second plot)