### PR TITLE
CLI: Updated `-sc` option to specify colors for multiple series

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ Options:
     	precision of data point labels along the y-axis (default 2)
   -r realtime
     	enables realtime graph for data stream
-  -sc series color
-    	series color of the plot
+  -sc series colors
+    	comma-separated series colors corresponding to each series
   -sn number of series
     	number of series (columns) in the input data (default 1)
   -ub upper bound


### PR DESCRIPTION
`-sc` option updated to support colors for multiple series

![asciigraph](https://github.com/guptarohit/asciigraph/assets/7895001/0b3dc706-11ff-4b2f-a21a-3a7a1440caf0)

above plot is rendered with following command:
```bash
{unbuffer` paste -d, <(ping -i 0.4 google.com | sed -u -n -E 's/.*time=(.*)ms.*/\1/p') <(ping -i 0.4 duckduckgo.com | sed -u -n -E 's/.*time=(.*)ms.*/\1/p') } | asciigraph -r -h 15 -w 60 -sn 2 -sc "blue,red" -c "Ping Latency Comparison: Google (Blue) vs. DuckDuckGo (Red)"
```