### PR TITLE
CLI: Added option `-sl` to specify legends for series

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Options:
     	enables realtime graph for data stream
   -sc series colors
     	comma-separated series colors corresponding to each series
+  -sl series legends
+    	comma-separated series legends corresponding to each series
   -sn number of series
     	number of series (columns) in the input data (default 1)
   -ub upper bound

--- a/cmd/asciigraph/main.go
+++ b/cmd/asciigraph/main.go
@@ -25,6 +25,7 @@ var (
 	realTimeDataBuffer int
 	fps                float64 = 24
 	seriesColors       []asciigraph.AnsiColor
+	seriesLegends      []string
 	captionColor       asciigraph.AnsiColor
 	axisColor          asciigraph.AnsiColor
 	labelColor         asciigraph.AnsiColor
@@ -85,6 +86,13 @@ func main() {
 			return nil
 		}
 	})
+	flag.Func("sl", "comma-separated `series legends` corresponding to each series", func(str string) error {
+		for _, legend := range strings.Split(str, ",") {
+			seriesLegends = append(seriesLegends, strings.TrimSpace(legend))
+		}
+		return nil
+	})
+
 	flag.Float64Var(&lowerBound, "lb", lowerBound, "`lower bound` set the minimum value for the vertical axis (ignored if series contains lower values)")
 	flag.Float64Var(&upperBound, "ub", upperBound, "`upper bound` set the maximum value for the vertical axis (ignored if series contains larger values)")
 	flag.StringVar(&delimiter, "d", delimiter, "data `delimiter` for splitting data points in the input stream")
@@ -141,6 +149,7 @@ func main() {
 					asciigraph.Precision(precision),
 					asciigraph.Caption(caption),
 					asciigraph.SeriesColors(seriesColors...),
+					asciigraph.SeriesLegends(seriesLegends...),
 					asciigraph.CaptionColor(captionColor),
 					asciigraph.AxisColor(axisColor),
 					asciigraph.LabelColor(labelColor),
@@ -169,6 +178,7 @@ func main() {
 			asciigraph.Precision(precision),
 			asciigraph.Caption(caption),
 			asciigraph.SeriesColors(seriesColors...),
+			asciigraph.SeriesLegends(seriesLegends...),
 			asciigraph.CaptionColor(captionColor),
 			asciigraph.AxisColor(axisColor),
 			asciigraph.LabelColor(labelColor),


### PR DESCRIPTION
`-sl` option added to specify legends for series

![asciigraph_legends](https://github.com/guptarohit/asciigraph/assets/7895001/fd20416b-731f-48b9-8cd2-000c7370bde0)

above plot is rendered with following command:
```bash
{unbuffer paste -d, <(ping -i 0.4 google.com | sed -u -n -E 's/.*time=(.*)ms.*/\1/p') <(ping -i 0.4 duckduckgo.com | sed -u -n -E 's/.*time=(.*)ms.*/\1/p') } | asciigraph -r -h 15 -w 60 -sn 2 -sc "blue,red" -c "Ping Latency Comparison" -sl "Google, DuckDuckGo"
```