### PR TITLE
Fix graph height calculation for small value ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.3] - 2024-10-26
+
+### Fixed
+
+- Incorrect plot height calculation for small value ranges (#59)
+
 ## [0.7.2] - 2024-08-12
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine AS builder
+FROM golang:1.23-alpine AS builder
 WORKDIR /app
 COPY cmd ./cmd
 COPY go.mod ./

--- a/asciigraph.go
+++ b/asciigraph.go
@@ -48,12 +48,12 @@ func PlotMany(data [][]float64, options ...Option) string {
 
 	minimum, maximum := math.Inf(1), math.Inf(-1)
 	for i := range data {
-		min, max := minMaxFloat64Slice(data[i])
-		if min < minimum {
-			minimum = min
+		minVal, maxVal := minMaxFloat64Slice(data[i])
+		if minVal < minimum {
+			minimum = minVal
 		}
-		if max > maximum {
-			maximum = max
+		if maxVal > maximum {
+			maximum = maxVal
 		}
 	}
 	if config.LowerBound != nil && *config.LowerBound < minimum {

--- a/asciigraph.go
+++ b/asciigraph.go
@@ -65,11 +65,7 @@ func PlotMany(data [][]float64, options ...Option) string {
 	interval := math.Abs(maximum - minimum)
 
 	if config.Height <= 0 {
-		if int(interval) <= 0 {
-			config.Height = int(interval * math.Pow10(int(math.Ceil(-math.Log10(interval)))))
-		} else {
-			config.Height = int(interval)
-		}
+		config.Height = calculateHeight(interval)
 	}
 
 	if config.Offset <= 0 {

--- a/asciigraph_test.go
+++ b/asciigraph_test.go
@@ -287,6 +287,19 @@ func TestPlot(t *testing.T) {
 			`
 \x1b[94m 1.00\x1b[0m \x1b[32m┤\x1b[0m╶
        \x1b[91mcolor test\x1b[0m`},
+		{
+			[]float64{.02, .03, .02},
+			nil,
+			`
+ 0.030 ┤╭╮
+ 0.020 ┼╯╰`},
+		{
+			[]float64{.2, .3, .1, .3},
+			nil,
+			`
+ 0.30 ┤╭╮╭
+ 0.20 ┼╯││
+ 0.10 ┤ ╰╯`},
 	}
 
 	for i := range cases {

--- a/utils.go
+++ b/utils.go
@@ -89,3 +89,17 @@ func init() {
 		}
 	}
 }
+
+func calculateHeight(interval float64) int {
+	if interval >= 1 {
+		return int(interval)
+	}
+
+	scaleFactor := math.Pow(10, math.Floor(math.Log10(interval)))
+	scaledDelta := interval / scaleFactor
+
+	if scaledDelta < 2 {
+		return int(math.Ceil(scaledDelta))
+	}
+	return int(math.Floor(scaledDelta))
+}


### PR DESCRIPTION
This merge request addresses an issue where graphs with small value ranges (less than 1) were not being displayed correctly, often resulting in a flat line at 0.00. This will resolve the issue #56.

The problem was caused by the height calculation rounding down to 0 for small intervals, which led to division by zero errors in subsequent calculations. This was also suggested by @palash25 in the comments of the issue, thanks.

Changes made to resolve the issue:
- Refactored the height calculation logic into a separate function `calculateHeight()`.
- Implemented a scaling mechanism for small intervals, i.e. when the difference in max & min values of series is <0

The solution maintains consistency in height calculation across different scales of data, so graphs with ranges like {0.2, 0.3, 0.1} will have a similar appearance to graphs with ranges like {2, 3, 1}.

Also, refactored a bit related to the conflicting name of variables with built-in methods.