### PR TITLE
feat(cli): clear only previous graph in realtime mode

### DIFF
--- a/asciigraph_test.go
+++ b/asciigraph_test.go
@@ -1,8 +1,10 @@
 package asciigraph
 
 import (
+	"bytes"
 	"fmt"
 	"math"
+	"os"
 	"strings"
 	"testing"
 )
@@ -830,6 +832,52 @@ func TestXAxis(t *testing.T) {
 			actual := PlotMany(c.data, c.opts...)
 			if actual != expected {
 				t.Errorf("expected:\n%s\n\ngot:\n%s", expected, actual)
+			}
+		})
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of f and returns whatever
+// was written to it.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() failed: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	f()
+
+	w.Close()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("reading captured stdout failed: %v", err)
+	}
+	return buf.String()
+}
+
+func TestClearLines(t *testing.T) {
+	cases := []struct {
+		n        int
+		expected string
+	}{
+		{0, ""},
+		{-1, ""},
+		{1, "\033[1A\033[J"},
+		{5, "\033[5A\033[J"},
+		{100, "\033[100A\033[J"},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			got := captureStdout(t, func() {
+				ClearLines(c.n)
+			})
+			if got != c.expected {
+				t.Errorf("ClearLines(%d) = %q, expected %q", c.n, got, c.expected)
 			}
 		})
 	}

--- a/cmd/asciigraph/main.go
+++ b/cmd/asciigraph/main.go
@@ -37,6 +37,7 @@ var (
 	xAxisMin           = math.NaN()
 	xAxisMax           = math.NaN()
 	xAxisTicks         int
+	lastGraphLines     int // Track last graph height for clearing in realtime mode
 )
 
 func main() {
@@ -186,8 +187,12 @@ func main() {
 					}
 				}
 				plot := asciigraph.PlotMany(seriesCopy, opts...)
-				asciigraph.Clear()
+				// Clear previous graph in realtime mode
+				clearPreviousGraph()
 				fmt.Println(plot)
+				// Record the number of lines for next clearing
+				lines := strings.Split(plot, "\n")
+				lastGraphLines = len(lines)
 				nextFlushTime = time.Now().Add(flushInterval)
 			}
 		}
@@ -243,6 +248,24 @@ func parseColors(colors string) ([]asciigraph.AnsiColor, bool) {
 	}
 
 	return parsedColors, true
+}
+
+// clearPreviousGraph clears the previous graph in realtime mode
+// by moving cursor up and clearing the lines
+func clearPreviousGraph() {
+	if lastGraphLines > 0 {
+		// Move cursor up by lastGraphLines
+		fmt.Printf("\033[%dA", lastGraphLines)
+		// Clear each line
+		for i := 0; i < lastGraphLines; i++ {
+			fmt.Print("\033[2K\r")
+			if i < lastGraphLines-1 {
+				fmt.Print("\033[B") // Move down one line
+			}
+		}
+		// Move cursor back to start position
+		fmt.Printf("\033[%dA", lastGraphLines)
+	}
 }
 
 func parseColor(color string) (asciigraph.AnsiColor, bool) {

--- a/cmd/asciigraph/main.go
+++ b/cmd/asciigraph/main.go
@@ -250,22 +250,10 @@ func parseColors(colors string) ([]asciigraph.AnsiColor, bool) {
 	return parsedColors, true
 }
 
-// clearPreviousGraph clears the previous graph in realtime mode
-// by moving cursor up and clearing the lines
+// clearPreviousGraph clears the previous graph in realtime mode by moving the
+// cursor up over the last graph and clearing to the end of the screen.
 func clearPreviousGraph() {
-	if lastGraphLines > 0 {
-		// Move cursor up by lastGraphLines
-		fmt.Printf("\033[%dA", lastGraphLines)
-		// Clear each line
-		for i := 0; i < lastGraphLines; i++ {
-			fmt.Print("\033[2K\r")
-			if i < lastGraphLines-1 {
-				fmt.Print("\033[B") // Move down one line
-			}
-		}
-		// Move cursor back to start position
-		fmt.Printf("\033[%dA", lastGraphLines)
-	}
+	asciigraph.ClearLines(lastGraphLines)
 }
 
 func parseColor(color string) (asciigraph.AnsiColor, bool) {

--- a/utils.go
+++ b/utils.go
@@ -69,7 +69,8 @@ func interpolateArray(data []float64, fitCount int) []float64 {
 	return interpolatedData
 }
 
-// clear terminal screen
+// Clear clears the entire terminal screen. On Windows it runs "cls"; on other
+// platforms it writes an ANSI clear sequence.
 var Clear func()
 
 func init() {
@@ -87,6 +88,15 @@ func init() {
 		Clear = func() {
 			fmt.Print("\033[2J\033[H")
 		}
+	}
+}
+
+// ClearLines erases the last n lines by moving the cursor up and clearing to
+// the end of the screen. Unlike Clear, content above those lines is preserved.
+// It is a no-op for n <= 0.
+func ClearLines(n int) {
+	if n > 0 {
+		fmt.Printf("\033[%dA\033[J", n)
 	}
 }
 


### PR DESCRIPTION
  **Summary**
  Fixes #44 by clearing only the previous graph instead of wiping the whole terminal in realtime mode, removing flicker and preserving any output above the graph.

  **Changes**
  - Add exported `asciigraph.ClearLines(n)` helper that erases the last `n` lines (cursor up + clear to end of screen) without touching content above them.
  - Realtime CLI now tracks the last graph height (`lastGraphLines`) and calls `ClearLines` instead of the full-screen `Clear()`.

  **Verification**
  - `go test ./...` (incl. new `TestClearLines`), `go vet ./...`, `gofmt`, and `GOARCH=arm` cross-compile all pass.
  - Manual: `seq 1 100 | go run ./cmd/asciigraph -r` redraws in place with no flicker; captured output contains zero full-screen `\033[2J` wipes.

  **Closes** #44